### PR TITLE
Fix a bug that occurs when oracle is not provided

### DIFF
--- a/analysis/src/prism_tracker/scripts/evaluation.py
+++ b/analysis/src/prism_tracker/scripts/evaluation.py
@@ -125,7 +125,7 @@ def perform_loo(graph: Graph, pickle_files: List[Union[str, pathlib.Path]], step
     This function performs a leave-one-out evaluation of with a provided set of input data.
 
     Args:
-    * graph (Graph): A graph object with a list of step objects and a dictionary containing transition probabilities.
+    * graph (Graph): a graph object with a list of step objects and a dictionary containing transition probabilities.
     * pickle_files (List[Union[str, pathlib.Path]]): a list of the paths to the pickle files containing the input data.
     * steps (List[str]): a list of strings representing the steps in the process.
     * start_step_indices (Optional[List[int]]): a list of integers representing the indices of the starting step.

--- a/analysis/src/prism_tracker/tracker/viterbi.py
+++ b/analysis/src/prism_tracker/tracker/viterbi.py
@@ -113,7 +113,7 @@ class ViterbiTracker:
                     elif oracle_next_step != transition.next_step_index:  # the next step should be a different one
                         continue
                 elif curr_state_index != transition.next_step_index and \
-                        transition.next_step_index in oracle_prohibited_steps:  # cannot transit now
+                        transition.next_step_index in (oracle_prohibited_steps or []):  # cannot transit now
                     continue
 
                 prob = curr_entry.probability + transition.probability + observed_probs[transition.next_step_index]


### PR DESCRIPTION
When no oracle is provided, `oracle_prohibited_steps` can be `None`, which occurs an error.